### PR TITLE
Fixed issue on new project didn't load on clicking close

### DIFF
--- a/components/projects/Projects.tsx
+++ b/components/projects/Projects.tsx
@@ -68,7 +68,9 @@ const Projects = ({
   const ProjectClasses = useProjectStyles();
   const [projectList, setProjectList] = React.useState<any>([]);
   const {setLoading, setAPIError} = useContext(ApiStatusContext);
-  const {loading, error, data} = useQuery(projectListQuery());
+  const {loading, error, data} = useQuery(projectListQuery(), {
+    fetchPolicy: 'network-only',
+  });
   React.useEffect(() => {
     if (data) {
       setProjectList(data.projects);


### PR DESCRIPTION
Issue: Newly created project didn't load on the create project screen
1.Created new project and navigate into project builder screen
2.Click close button and navigate to create project screen
3.List of project didn't had the newly created project

Changes done:
Added fetch policy on the project list query to fix the issue